### PR TITLE
Incorporated JWT Refresh Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # MycoTex backend
 
-
 ## Summary
+
 This project is the core server-side code for
 [Myco-tex](url tbd).
 This website provides:
@@ -19,20 +19,25 @@ Current work is focused on establishing a monitoring system and database for tem
 
 ## Related Projects/Modules
 
-**myco-tex-backend** (https://github.com/BenjaminDBallard/myco-tex-backend) (This project)    
+**myco-tex-backend** (https://github.com/BenjaminDBallard/myco-tex-backend) (This project)
+
 - Serves up REST endpoints for dashboard application using express, node, & mysql2. Authorization and security for the API use JWT and Bcrypt.
 
-**myco-tex-dashboard** (https://github.com/jason-cornish/myco-tex-dashboard)  
+**myco-tex-dashboard** (https://github.com/jason-cornish/myco-tex-dashboard)
+
 - This is the main dashboard application used for monitoring facility enviromental status with React & Styled-Components.
 
-**myco-tex-sensors** (https://github.com/BenjaminDBallard/myco-tex-sensors)  
+**myco-tex-sensors** (https://github.com/BenjaminDBallard/myco-tex-sensors)
+
 - Contains scripts to effectively recieve and send temps, humitity, co2 and other enviromental variables using C++ with the Arduino IDE.
 
 <br/>
 <hr/>
 
 ## Development
+
 **Main**
+
 - [x] Initialize DB
 - [x] Complete core routers & controllers
 - [x] Ensure response outputs are formated
@@ -43,16 +48,19 @@ Current work is focused on establishing a monitoring system and database for tem
 - [ ] Set up JWT token refresh
 
 **Quality Assurance**
+
 - [ ] Review error handling. (Some GET request and multi-insert errors slip through the cracks)
 - [ ] Test and ensure optional params are actually optional
 
 **Final**
+
 - [ ] DEPLOY to Digital Ocean droplets
 
 <br/>
 <hr/>
 
 # Project Setup
+
 > [!TIP]
 >
 > ```
@@ -96,19 +104,20 @@ Current work is focused on establishing a monitoring system and database for tem
 
 ## Report:
 
-| Request | Endpoint | Description |
-| ----:|:------------------------:|:----------------------------------------------------------|
-| GET  | `/api/report`    | Returns a json output showing all current ID's needed to navigate API |  
+| Request |   Endpoint    | Description                                                           |
+| ------: | :-----------: | :-------------------------------------------------------------------- |
+|     GET | `/api/report` | Returns a json output showing all current ID's needed to navigate API |
 
 <br/>
 <hr/>
 
 ## Measure:
->:/hist = (true or false) determines whether you recieve the single current value or all historical values
 
-| Request | Endpoint | Description |
-| ----:|:------------------------:|:----------------------------------------------------------|
-| GET |  `/api/measure/:room_id/:hist`  | Returns a Json file showing all measurements from all controllers within a room |  
+> :/hist = (true or false) determines whether you recieve the single current value or all historical values
+
+| Request |           Endpoint            | Description                                                                     |
+| ------: | :---------------------------: | :------------------------------------------------------------------------------ |
+|     GET | `/api/measure/:room_id/:hist` | Returns a Json file showing all measurements from all controllers within a room |
 
 <br/>
 <hr/>
@@ -117,25 +126,27 @@ Current work is focused on establishing a monitoring system and database for tem
 
 **Endpoints**
 
-| Request | Endpoint | Parameters | Description |  
-| ----:|:------------------------:|:---------------------:|:-------------------------------------|  
-| POST |    `/api/user/signup`    | user_email <br/> user_pass <br/> user_company_name | Signs user up and populates a location and standard rooms |  
-| POST |    `/api/user/login`     | user_email <br/> user_pass | Verifies user and returns JWT |  
-| PUT  |    `/api/user/update`    | user_email <br/> user_pass <br/> user_company_name | Update user email, pass, and/or company name |
+| Request |      Endpoint       |                     Parameters                     | Description                                                                                                                                                         |
+| ------: | :-----------------: | :------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|    POST | `/api/user/signup`  | user_email <br/> user_pass <br/> user_company_name | Signs user up and populates a location and standard rooms                                                                                                           |
+|    POST |  `/api/user/login`  |             user_email <br/> user_pass             | Verifies user and returns JWT token and refresh token. the token for the client is stored in the res.headers and the refresh token is stored in an httpOnly cookie. |
+|    POST | `/api/user/refresh` |                        N/A                         | verifies that user has a refresh token, and if valid, returns a new token for the client in res.headers                                                             |
+|     PUT | `/api/user/update`  | user_email <br/> user_pass <br/> user_company_name | Update user email, pass, and/or company name                                                                                                                        |
 
 <br/>
 
-**Parameter Info**  
+**Parameter Info**
 
-| Name | Required | Type | Description |  
-| ----:|:--------:|:------:|:----------------------------------------------------|  
-| user_email | yes | string | The email of the user |  
-| user_pass | yes | string | The password of the user |  
-| user_company_name | optional | string <br/> null | The company of the user |  
+|              Name | Required |       Type        | Description              |
+| ----------------: | :------: | :---------------: | :----------------------- |
+|        user_email |   yes    |      string       | The email of the user    |
+|         user_pass |   yes    |      string       | The password of the user |
+| user_company_name | optional | string <br/> null | The company of the user  |
 
 <br/>
 
 **Example Request Body**
+
 ```
 {
     "user_email": "test@test.com",
@@ -151,22 +162,23 @@ Current work is focused on establishing a monitoring system and database for tem
 
 **Endpoints**
 
-| Request | Endpoint | Parameters | Description |  
-| ----:|:------------------------:|:---------------------:|:-------------------------------------|  
-| POST | `/api/location/new` | location_title | Add new location to user |
-| PUT | `/api/location/update/:location_id` | location_title | Update location title |
+| Request |              Endpoint               |   Parameters   | Description              |
+| ------: | :---------------------------------: | :------------: | :----------------------- |
+|    POST |         `/api/location/new`         | location_title | Add new location to user |
+|     PUT | `/api/location/update/:location_id` | location_title | Update location title    |
 
 <br/>
 
-**Parameter Info**  
+**Parameter Info**
 
-| Name | Required | Type | Description |  
-| ----:|:--------:|:------:|:----------------------------------------------------|  
+|           Name | Required |       Type        | Description              |
+| -------------: | :------: | :---------------: | :----------------------- |
 | location_title | optional | string <br/> null | Prefered name of the lab |
 
 <br/>
 
 **Example Request Body**
+
 ```
 {
     "location_title": "Incubation",
@@ -180,22 +192,23 @@ Current work is focused on establishing a monitoring system and database for tem
 
 **Endpoints**
 
-| Request | Endpoint | Parameters | Description |  
-| ----:|:------------------------:|:---------------------:|:-------------------------------------|  
-| POST | `/api/room/new/:location_id` | room_title | Add new room to location |  
-| PUT | `/api/room/update/:room_id` | room_title | Update room title |  
+| Request |           Endpoint           | Parameters | Description              |
+| ------: | :--------------------------: | :--------: | :----------------------- |
+|    POST | `/api/room/new/:location_id` | room_title | Add new room to location |
+|     PUT | `/api/room/update/:room_id`  | room_title | Update room title        |
 
 <br/>
 
-**Parameter Info**  
+**Parameter Info**
 
-| Name | Required | Type | Description |  
-| ----:|:--------:|:------:|:----------------------------------------------------|  
-| room_title | optional | string <br/> null | Prefered name of the room |  
+|       Name | Required |       Type        | Description               |
+| ---------: | :------: | :---------------: | :------------------------ |
+| room_title | optional | string <br/> null | Prefered name of the room |
 
 <br/>
 
 **Example Request Body**
+
 ```
 {
     "room_title": "North Wall",
@@ -209,31 +222,32 @@ Current work is focused on establishing a monitoring system and database for tem
 
 **Endpoints**
 
-| Request | Endpoint | Parameters | Description |  
-| ----:|:------------------------:|:---------------------:|:-------------------------------------| 
-| POST | `/api/device/new/:room_id` | controller_id <br/> device_pass <br/> controller_name <br/> controller_serial <br/> controller_make <br/> controller_model <br/> probe_id <br/> probe_make <br/> probe_model <br/> probe_type | Adds new device (multi-inserts into controller, probe, and device tables) |  
-| PUT | `/api/device/update/:controller_id` | room_id <br/> controller_name | Update device name and/or move device to different room
+| Request |              Endpoint               |                                                                                          Parameters                                                                                           | Description                                                               |
+| ------: | :---------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------ |
+|    POST |     `/api/device/new/:room_id`      | controller_id <br/> device_pass <br/> controller_name <br/> controller_serial <br/> controller_make <br/> controller_model <br/> probe_id <br/> probe_make <br/> probe_model <br/> probe_type | Adds new device (multi-inserts into controller, probe, and device tables) |
+|     PUT | `/api/device/update/:controller_id` |                                                                                 room_id <br/> controller_name                                                                                 | Update device name and/or move device to different room                   |
 
 <br/>
 
-**Parameter Info**  
+**Parameter Info**
 
-| Name | Required | Type | Description |  
-| ----:|:--------:|:------:|:----------------------------------------------------|  
-| controller_id | yes | string | ID of the device (supplied with controller on delivery) |
-| device_pass | yes | string | Password of the device (supplied with controller) |
-| controller_name | optional | string | Prefered name of device |
-| controller_serial | optional | string | Serial number of the ESP32 |
-| controller_make |  optional | string | Make of ESP32 (Arduino, Esspressif, ect) |
-| controller_model | optional | string | Model of ESP32 (devkit esp32-wroom-32u) |
-| probe_id | yes | string | ID of probe/reader/thermostat (supplied with controller on delivery) |  
-| probe_make | optional | string | Make/Brand of probe/reader/thermostat (BOJACK, Weewooday, ect) |  
-| probe_model | optional | string | Model of ESP32 (DS18B20, DHT11, DHT22, ect) |
-| probe_type | optional | string | Type of probe (therm, co2, ppm, hum)
+|              Name | Required |  Type  | Description                                                          |
+| ----------------: | :------: | :----: | :------------------------------------------------------------------- |
+|     controller_id |   yes    | string | ID of the device (supplied with controller on delivery)              |
+|       device_pass |   yes    | string | Password of the device (supplied with controller)                    |
+|   controller_name | optional | string | Prefered name of device                                              |
+| controller_serial | optional | string | Serial number of the ESP32                                           |
+|   controller_make | optional | string | Make of ESP32 (Arduino, Esspressif, ect)                             |
+|  controller_model | optional | string | Model of ESP32 (devkit esp32-wroom-32u)                              |
+|          probe_id |   yes    | string | ID of probe/reader/thermostat (supplied with controller on delivery) |
+|        probe_make | optional | string | Make/Brand of probe/reader/thermostat (BOJACK, Weewooday, ect)       |
+|       probe_model | optional | string | Model of ESP32 (DS18B20, DHT11, DHT22, ect)                          |
+|        probe_type | optional | string | Type of probe (therm, co2, ppm, hum)                                 |
 
 <br/>
 
 **Example Request Body**
+
 ```
 {
     "controller_id": "12345990011",
@@ -252,35 +266,35 @@ Current work is focused on establishing a monitoring system and database for tem
 <br/>
 <hr/>
 
-## Measurements: 
+## Measurements:
 
->:/hist = (true or false) determines whether you recieve the single current value or all historical values
+> :/hist = (true or false) determines whether you recieve the single current value or all historical values
 
 **Endpoints**
 
-| Request | Endpoint | Parameters | Description |  
-| ----:|:------------------------:|:---------------------:|:-------------------------------------| 
-| GET | `/api/co2/:probe_id/:hist` | N/A | Get historical or current device measurement |
-| GET | `/api/hum/:probe_id/:hist` | N/A | Get historical or current device measurement |
-| GET | `/api/ppm/:probe_id/:hist` | N/A | Get historical or current device measurement |
-| GET | `/api/temp/:probe_id/:hist` | N/A | Get historical or current device measurement |
-| POST | `/api/co2/new/:probe_id` | controller_id <br/> device_pass <br/> probe_co2_measure | Post new co2 measurement |
-| POST | `/api/hum/new/:probe_id` | controller_id <br/> device_pass <br/> probe_co2_measure | Post new humidity measurement |
-| POST | `/api/ppm/new/:probe_id` | controller_id <br/> device_pass <br/> probe_co2_measure | Post new ppm measurement |
-| POST | `/api/temp/new/:probe_id` | controller_id <br/> device_pass <br/> probe_co2_measure | Post new temperature measurement |
+| Request |          Endpoint           |                       Parameters                        | Description                                  |
+| ------: | :-------------------------: | :-----------------------------------------------------: | :------------------------------------------- |
+|     GET | `/api/co2/:probe_id/:hist`  |                           N/A                           | Get historical or current device measurement |
+|     GET | `/api/hum/:probe_id/:hist`  |                           N/A                           | Get historical or current device measurement |
+|     GET | `/api/ppm/:probe_id/:hist`  |                           N/A                           | Get historical or current device measurement |
+|     GET | `/api/temp/:probe_id/:hist` |                           N/A                           | Get historical or current device measurement |
+|    POST |  `/api/co2/new/:probe_id`   | controller_id <br/> device_pass <br/> probe_co2_measure | Post new co2 measurement                     |
+|    POST |  `/api/hum/new/:probe_id`   | controller_id <br/> device_pass <br/> probe_co2_measure | Post new humidity measurement                |
+|    POST |  `/api/ppm/new/:probe_id`   | controller_id <br/> device_pass <br/> probe_co2_measure | Post new ppm measurement                     |
+|    POST |  `/api/temp/new/:probe_id`  | controller_id <br/> device_pass <br/> probe_co2_measure | Post new temperature measurement             |
 
 <br/>
 
-**Parameter Info**  
+**Parameter Info**
 
-| Name | Required | Type | Description |  
-| ----:|:--------:|:------:|:----------------------------------------------------|  
-| controller_id | yes | string | ID of the device (supplied with controller on delivery) |
-| device_pass | yes | string | Password of the device (supplied with controller) |
-| probe_co2_measure | yes | int | Current measurement of co2 probe |
-| probe_hum_measure | yes | int | Current measurement of humidity probe |
-| probe_ppm_measure | yes | int | Current measurement of ppm probe |
-| probe_temp_measure | yes | int | Current measurement of temperature probe |
+|               Name | Required |  Type  | Description                                             |
+| -----------------: | :------: | :----: | :------------------------------------------------------ |
+|      controller_id |   yes    | string | ID of the device (supplied with controller on delivery) |
+|        device_pass |   yes    | string | Password of the device (supplied with controller)       |
+|  probe_co2_measure |   yes    |  int   | Current measurement of co2 probe                        |
+|  probe_hum_measure |   yes    |  int   | Current measurement of humidity probe                   |
+|  probe_ppm_measure |   yes    |  int   | Current measurement of ppm probe                        |
+| probe_temp_measure |   yes    |  int   | Current measurement of temperature probe                |
 
 <br/>
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "body-parser": "^1.20.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/body-parser": "^1.19.5",
+    "@types/cookie-parser": "^1.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,13 @@ import probeThermRouter from "./routes/probeTherm.js";
 import apiRouter from "./routes/api.js";
 import deviceRouter from "./routes/device.js";
 import { verifyJWT } from "./middleware/verifyJwt.js";
+import cookies from "cookie-parser";
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
+app.use(cookies());
 
 app.get("/isUserAuth", verifyJWT, (req, res) => {
   res.send("You are authenticated Congrats:");

--- a/src/middleware/verifyJwt.ts
+++ b/src/middleware/verifyJwt.ts
@@ -1,5 +1,5 @@
-import { NextFunction } from "express";
-import jwt from "jsonwebtoken";
+import { NextFunction, Request, Response } from "express";
+import jwt, { Secret, JwtPayload } from "jsonwebtoken";
 /*This middleware function can be used before accessing protected routes to confirm that
 1) An auth-token is present on the request
 2) The auth-token in the request is valid
@@ -8,36 +8,42 @@ If both conditions are met, then the next() function is called, allowing access 
 Example of how to use verifyJWT:
 router.post("/protected-route", verifyJWTFunction, protectedRouteFunction);
 */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const verifyJWT = (req: any, res: any, next: NextFunction) => {
+export const SECRET_KEY: Secret = process.env.access_token!;
+
+export const verifyJWT = (req: Request, res: Response, next: NextFunction) => {
+  const token = req.headers["x-access-token"];
+  const refreshToken = req.cookies["x-refresh-token"];
+
+  if (!token && !refreshToken) {
+    return res.status(401).send("Access Denied. No token provided.");
+  }
+
   try {
-    const token = req.headers["x-access-token"];
-    if (!token) {
-      res.send("Auth token not included in request");
-    } else {
-      const accessToken: string | undefined = process.env.access_token;
-      if (!accessToken) return res.status(500).send("Access token not found");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      jwt.verify(token, accessToken, (err: any, decoded: any) => {
-        if (err) {
-          console.log(err);
-          res.status(401).json({
-            auth: false,
-            message: "Your auth token is invalid or expired",
-            status: 401,
-          });
-        } else if (
-          typeof decoded !== "undefined" &&
-          // eslint-disable-next-line no-prototype-builtins
-          decoded.hasOwnProperty("id")
-        ) {
-          const id: string = decoded.id;
-          req.params.user_id = id;
-          next();
-        }
-      });
+    const decoded = jwt.verify(token as string, SECRET_KEY) as JwtPayload;
+    req.params.user_id = decoded.id;
+    next();
+  } catch (error) {
+    if (!refreshToken) {
+      return res.status(401).send("Access Denied. No refresh token provided.");
     }
-  } catch {
-    return res.status(401).send("Your auth token has expired");
+
+    try {
+      const decoded = jwt.verify(refreshToken, SECRET_KEY) as JwtPayload;
+      const token = jwt.sign({ id: decoded.id }, SECRET_KEY, {
+        expiresIn: "1h",
+      });
+      const NewRefreshToken = jwt.sign({ id: decoded.id }, SECRET_KEY, {
+        expiresIn: "24h",
+      });
+      res
+        .cookie("x-refresh-token", NewRefreshToken, {
+          httpOnly: true,
+          sameSite: "strict",
+        })
+        .header("x-access-token", token)
+        .send(decoded.id);
+    } catch (error) {
+      return res.status(401).send("Invalid Token. Please Login.");
+    }
   }
 };

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -4,6 +4,7 @@ import {
   logIn,
   // getUser,
   updateUser,
+  refreshJWT,
 } from "../controllers/user.js";
 import { verifyJWT } from "../middleware/verifyJwt.js";
 
@@ -11,6 +12,7 @@ const router = Router();
 
 router.post("/signup", signUp);
 router.post("/login", logIn);
+router.post("/refresh", refreshJWT);
 // router.get("/", verifyJWT, getUser);
 router.put("/update", verifyJWT, updateUser);
 


### PR DESCRIPTION
 - JWT access tokens are now stores in res.headers as `x-access-token`
 - JWT refresh tokens are stored in an httpOnly cookie as `x-refresh-token`
 
The verifyJWT middleware automatically refreshes both the x-access-token and the x-refresh-token if the original x-refresh-token is still valid.

for any other use case there is a dedicated endpoint to refresh: `/api/user/refresh` which also refreshes both tokens.

current token duration is as follows:
x-access-token: 1 hour
x-refresh-token: 24 hours